### PR TITLE
fixed mocha-phantomjs 'SSL handshake failed'

### DIFF
--- a/lesson7/README.md
+++ b/lesson7/README.md
@@ -102,18 +102,20 @@ npm i -g mocha-phantomjs
 
 ```html
 <script>
-  if (window.mochaPhantomJS) {
-    mochaPhantomJS.run();
-  } else {
-    mocha.run();
+  if (window.initMochaPhantomJS && window.location.search.indexOf('skip') === -1) {
+    initMochaPhantomJS()
   }
+  mocha.ui('bdd');
+  expect = chai.expect;
+  
+  mocha.run();
 </script>
 ```
 
 这时候, 我们在命令行中运行
 
 ```shell
-mocha-phantomjs index.html
+mocha-phantomjs index.html --ssl-protocol=any --ignore-ssl-errors=true
 ```
 
 结果展现是不是和后端代码测试很类似 :smile:
@@ -123,7 +125,7 @@ mocha-phantomjs index.html
 
 ```json
 "scripts": {
-  "test": "mocha-phantomjs index.html"
+  "test": "mocha-phantomjs index.html --ssl-protocol=any --ignore-ssl-errors=true"
 },
 ```
 

--- a/lesson7/vendor/index.html
+++ b/lesson7/vendor/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="mocha"></div>
-    <script src='https://raw.githubusercontent.com/chaijs/chai/master/chai.js'></script>
+    <script src='https://cdn.rawgit.com/chaijs/chai/master/chai.js'></script>
     <script>
       var fibonacci = function (n) {
         if (n === 0) {
@@ -24,11 +24,13 @@
     <script>mocha.setup('bdd')</script>
     <script src="tests.js"></script>
     <script>
-      if (window.mochaPhantomJS) {
-        mochaPhantomJS.run();
-      } else {
-        mocha.run();
+      if (window.initMochaPhantomJS) {
+        initMochaPhantomJS();
+        mocha.ui('bdd');
+        expect = chai.expect;
       }
+
+      mocha.run();
     </script>
   </body>
 </html>


### PR DESCRIPTION
运行 `mocha-phantomjs index.html` 报错
> mocha-phantomjs 4.0.1 (当前最新版)  

```
Error loading resource https://cdn.rawgit.com/chaijs/chai/master/chai.js (6). Details: SSL handshake failed
ReferenceError: Can't find variable: chai
```
参见：[nathanboktae/mocha-phantomjs/#173](https://github.com/nathanboktae/mocha-phantomjs/issues/173)