### PR TITLE
修复在OS X下，当前shell第一次执行nvm会找不到命令的问题。

### DIFF
--- a/lesson0/README.md
+++ b/lesson0/README.md
@@ -21,6 +21,16 @@ $ nvm
 ```
 
 当看到有输出时，则 nvm 安装成功。
+如果遇到关闭shell后遇到以下提示:  
+
+```
+-bash: nvm: command not found
+```
+请执行:  
+
+```
+$ source ~/.nvm/nvm.sh
+```
 
 ### 安装 Node.js
 


### PR DESCRIPTION
环境：OS X
问题：当第一次执行完$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.2/install.sh | bash或者重新运行shell时，会提示-bash: nvm: command not found，这对初学者来说是致命的。
解决办法：执行 source ~/.nvm/nvm.sh
个人看法：我也是您的《Node.js 包教不包会》的受益者，感谢您能在百忙中写出这么良心的书，祝身体健康，工作顺利。