### PR TITLE
兼容新版本依赖下，运行测试用例时重复监听同一端口的问题

### DIFF
--- a/lesson8/app.js
+++ b/lesson8/app.js
@@ -35,6 +35,10 @@ app.get('/fib', function (req, res) {
 
 module.exports = app;
 
-app.listen(3000, function () {
-  console.log('app is listening at port 3000');
-});
+// 测试用例运行时，不监听端口 
+// 兼容新版本依赖下，运行测试用例时重复监听同一端口，导致测试用例无法退出（端口没有被使用）或监听端口报错的问题（端口已被使用）
+if(!module.parent){
+  app.listen(3000, function () {
+    console.log('app is listening at port 3000');
+  });
+}


### PR DESCRIPTION
兼容高版本环境下的测试用例

高版本环境下：
Node.js: 10.15.2
mocha: 6.1.4
should: 13.2.3
supertest: 4.0.2
express: 4.17.0

运行测试用例会占用3000端口，可能导致：
1.app已运行的情况下，会报端口已被占用的错误
2.app没有运行，测试用例运行后没有退出，继续监听端口

解决方法：
根据module.parent判断是否为运行测试用例，是的话则不监听端口